### PR TITLE
Fixed ENV vars not being passed to workers

### DIFF
--- a/ClusterManager.js
+++ b/ClusterManager.js
@@ -183,7 +183,7 @@ module.exports = function ClusterManager(options) {
       }
       return;
     }
-    origFork.bind(this)();
+    origFork.bind(this)(config.env);
   };
 
   log('Master process PID is ' + process.pid);


### PR DESCRIPTION
ENV vars passed in the config weren't being passed to the workers. This fixes that :)